### PR TITLE
Resolves `spawn npm ENOENT` error on windows

### DIFF
--- a/bin/update.js
+++ b/bin/update.js
@@ -30,7 +30,8 @@ async function main ({ argv }) {
   // run install script to download updated binary
   await new Promise((resolve, reject) => {
     let opts = {
-      stdio: 'inherit'
+      stdio: 'inherit',
+      shell: true      
     }
     let install = spawn('npm', ['run', 'install'], opts)
     install.once('close', (code) => {


### PR DESCRIPTION
Fix for https://github.com/nomic-io/tendermint-node/issues/9